### PR TITLE
Fix requiring `input` when `help` command is provided

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,5 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+
+- [Fix required input error when `help` command is provided](https://github.com/ballerina-platform/ballerina-standard-library/issues/4446)
+
+## [0.1.0] - 2023-02-24
+
 ### Added
 - [Implement protobuf stub generation through protoc-tools](https://github.com/ballerina-platform/ballerina-standard-library/issues/3019)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina
-version=0.1.0-SNAPSHOT
+version=0.1.1-SNAPSHOT
 #dependency versions
 ballerinaLangVersion=2201.5.0-20230404-105200-b8aec90e
 checkstylePluginVersion=8.18

--- a/protoc-cli/src/main/java/io/ballerina/protoc/protobuf/cmd/GrpcCmd.java
+++ b/protoc-cli/src/main/java/io/ballerina/protoc/protobuf/cmd/GrpcCmd.java
@@ -475,8 +475,4 @@ public class GrpcCmd implements BLauncherCmd {
     public void setImportPath(String importPath) {
         this.importPath = importPath;
     }
-
-    public void setHelpFlag(boolean helpFlag) {
-        this.helpFlag = helpFlag;
-    }
 }

--- a/protoc-cli/src/main/java/io/ballerina/protoc/protobuf/cmd/GrpcCmd.java
+++ b/protoc-cli/src/main/java/io/ballerina/protoc/protobuf/cmd/GrpcCmd.java
@@ -76,7 +76,7 @@ public class GrpcCmd implements BLauncherCmd {
 
     private CommandLine parentCmdParser;
 
-    @CommandLine.Option(names = {"-h", "--help"}, hidden = true)
+    @CommandLine.Option(names = {"-h", "--help"}, hidden = true, usageHelp = true)
     private boolean helpFlag;
 
     @CommandLine.Option(names = {"--input"}, description = "Input .proto file or a directory containing " +
@@ -474,5 +474,9 @@ public class GrpcCmd implements BLauncherCmd {
 
     public void setImportPath(String importPath) {
         this.importPath = importPath;
+    }
+
+    public void setHelpFlag(boolean helpFlag) {
+        this.helpFlag = helpFlag;
     }
 }


### PR DESCRIPTION
## Purpose
$subject

Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/4446
Since output cannot be read from tests, added the relevant tests to the distribution
https://github.com/ballerina-platform/ballerina-distribution/pull/4433

```
bal grpc -h


NAME
       ballerina-grpc - Generate Ballerina sources for the given Protocol Buffer
                        definition

SYNOPSIS
       bal grpc --input <proto-file-path> [--output <path>]
                        [--mode mode]
                        [--proto-path <path>]

DESCRIPTION
       Generate the Ballerina gRPC client/service sources for a given
       gRPC protocol buffer (Protobuf) definition.

OPTIONS
       --input <path>
           Path to a '.proto' file or a directory containing multiple '.proto'
           files.

       --output <path>
           Location of the generated Ballerina source files.
           If the output path is not specified, the output will be written to a
           directory corresponding to the package in the protocol buffer
           definition. If a package is not specified, the output will be written
           to a 'temp' directory in the current location.

       --mode mode
           Set the 'client' or 'service' mode to generate sample code.
           If not specified, only the stub file is generated.

       --proto-path <path>
            Path to a directory in which to look for '.proto' files when
            resolving import directives.

EXAMPLES
       Generate the Ballerina gRPC stub file (for the given '.proto' file) in a
       'stub' directory.
           $ bal grpc --input chat.proto --output stub

       Generate the Ballerina gRPC stub file and client sample code (for the
       given '.proto' file) in a 'client' directory.
           $ bal grpc --input chat.proto --output client --mode client

       Generate the Ballerina gRPC stub file and service sample code (for the
       given '.proto' file) in a 'service' directory.
           $ bal grpc --input chat.proto --output service --mode service
```

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
