### PR TITLE
Refator Code to use `!is` instead of `!(<variable> is <type>)`

### DIFF
--- a/protoc-cli/src/main/java/io/ballerina/protoc/builder/syntaxtree/components/Expression.java
+++ b/protoc-cli/src/main/java/io/ballerina/protoc/builder/syntaxtree/components/Expression.java
@@ -234,6 +234,15 @@ public class Expression {
         );
     }
 
+    public static TypeTestExpressionNode getUnaryTypeTestExpressionNode(ExpressionNode expression,
+                                                                        Node typeDescriptor) {
+        return NodeFactory.createTypeTestExpressionNode(
+                expression,
+                SyntaxTreeConstants.SYNTAX_TREE_KEYWORD_NOT_IS,
+                typeDescriptor
+        );
+    }
+
     public static CheckExpressionNode getCheckExpressionNode(ExpressionNode expression) {
         return NodeFactory.createCheckExpressionNode(
                 SyntaxKind.CHECK_ACTION,

--- a/protoc-cli/src/main/java/io/ballerina/protoc/builder/syntaxtree/constants/SyntaxTreeConstants.java
+++ b/protoc-cli/src/main/java/io/ballerina/protoc/builder/syntaxtree/constants/SyntaxTreeConstants.java
@@ -73,7 +73,7 @@ public class SyntaxTreeConstants {
     public static final Token SYNTAX_TREE_KEYWORD_IF = AbstractNodeFactory.createIdentifierToken("if ");
     public static final Token SYNTAX_TREE_KEYWORD_ELSE = AbstractNodeFactory.createIdentifierToken("else ");
     public static final Token SYNTAX_TREE_KEYWORD_IS = AbstractNodeFactory.createIdentifierToken("is ");
-    public static final Token SYNTAX_TREE_KEYWORD_NOT_IS = AbstractNodeFactory.createIdentifierToken("!is");
+    public static final Token SYNTAX_TREE_KEYWORD_NOT_IS = AbstractNodeFactory.createIdentifierToken("!is ");
     public static final Token SYNTAX_TREE_KEYWORD_LISTENER = AbstractNodeFactory.createIdentifierToken("listener ");
     public static final Token SYNTAX_TREE_KEYWORD_SERVICE = AbstractNodeFactory.createIdentifierToken("service ");
     public static final Token SYNTAX_TREE_KEYWORD_ON = AbstractNodeFactory.createIdentifierToken("on ");

--- a/protoc-cli/src/main/java/io/ballerina/protoc/builder/syntaxtree/constants/SyntaxTreeConstants.java
+++ b/protoc-cli/src/main/java/io/ballerina/protoc/builder/syntaxtree/constants/SyntaxTreeConstants.java
@@ -61,7 +61,6 @@ public class SyntaxTreeConstants {
     public static final Token SYNTAX_TREE_UNDERSCORE = AbstractNodeFactory.createIdentifierToken("_");
     public static final Token SYNTAX_TREE_OPTIONAL_CHAINING = AbstractNodeFactory.createIdentifierToken("?.");
     public static final Token SYNTAX_TREE_AT = AbstractNodeFactory.createIdentifierToken("@");
-
     public static final Token SYNTAX_TREE_KEYWORD_NEW = AbstractNodeFactory.createIdentifierToken("new ");
     public static final Token SYNTAX_TREE_KEYWORD_IMPORT = AbstractNodeFactory.createIdentifierToken("import ");
     public static final Token SYNTAX_TREE_KEYWORD_CHECK = AbstractNodeFactory.createIdentifierToken("check ");
@@ -74,6 +73,7 @@ public class SyntaxTreeConstants {
     public static final Token SYNTAX_TREE_KEYWORD_IF = AbstractNodeFactory.createIdentifierToken("if ");
     public static final Token SYNTAX_TREE_KEYWORD_ELSE = AbstractNodeFactory.createIdentifierToken("else ");
     public static final Token SYNTAX_TREE_KEYWORD_IS = AbstractNodeFactory.createIdentifierToken("is ");
+    public static final Token SYNTAX_TREE_KEYWORD_NOT_IS = AbstractNodeFactory.createIdentifierToken("!is");
     public static final Token SYNTAX_TREE_KEYWORD_LISTENER = AbstractNodeFactory.createIdentifierToken("listener ");
     public static final Token SYNTAX_TREE_KEYWORD_SERVICE = AbstractNodeFactory.createIdentifierToken("service ");
     public static final Token SYNTAX_TREE_KEYWORD_ON = AbstractNodeFactory.createIdentifierToken("on ");

--- a/protoc-cli/src/main/java/io/ballerina/protoc/builder/syntaxtree/utils/MessageUtils.java
+++ b/protoc-cli/src/main/java/io/ballerina/protoc/builder/syntaxtree/utils/MessageUtils.java
@@ -46,8 +46,7 @@ import static io.ballerina.protoc.builder.syntaxtree.components.Expression.getBr
 import static io.ballerina.protoc.builder.syntaxtree.components.Expression.getFieldAccessExpressionNode;
 import static io.ballerina.protoc.builder.syntaxtree.components.Expression.getMethodCallExpressionNode;
 import static io.ballerina.protoc.builder.syntaxtree.components.Expression.getOptionalFieldAccessExpressionNode;
-import static io.ballerina.protoc.builder.syntaxtree.components.Expression.getTypeTestExpressionNode;
-import static io.ballerina.protoc.builder.syntaxtree.components.Expression.getUnaryExpressionNode;
+import static io.ballerina.protoc.builder.syntaxtree.components.Expression.getUnaryTypeTestExpressionNode;
 import static io.ballerina.protoc.builder.syntaxtree.components.Literal.getBooleanLiteralNode;
 import static io.ballerina.protoc.builder.syntaxtree.components.Literal.getNumericLiteralNode;
 import static io.ballerina.protoc.builder.syntaxtree.components.Statement.getCompoundAssignmentStatementNode;
@@ -247,14 +246,10 @@ public class MessageUtils {
             function.addVariableStatement(count.getVariableDeclarationNode());
             for (Field field : oneOfFieldMap.getValue()) {
                 IfElse oneOfFieldCheck = new IfElse(
-                        getUnaryExpressionNode(
-                                getBracedExpressionNode(
-                                        getTypeTestExpressionNode(
-                                                getOptionalFieldAccessExpressionNode("r", field.getFieldName()),
-                                                getNilTypeDescriptorNode()
-                                        )
-                                )
-                        )
+                    getUnaryTypeTestExpressionNode(
+                            getOptionalFieldAccessExpressionNode("r", field.getFieldName()),
+                            getNilTypeDescriptorNode()
+                    )
                 );
                 oneOfFieldCheck.addIfStatement(
                         getCompoundAssignmentStatementNode(

--- a/protoc-cli/src/main/java/io/ballerina/protoc/builder/syntaxtree/utils/MessageUtils.java
+++ b/protoc-cli/src/main/java/io/ballerina/protoc/builder/syntaxtree/utils/MessageUtils.java
@@ -42,7 +42,6 @@ import java.util.Map;
 
 import static io.ballerina.protoc.GrpcConstants.ANN_DESCRIPTOR;
 import static io.ballerina.protoc.builder.syntaxtree.components.Expression.getBinaryExpressionNode;
-import static io.ballerina.protoc.builder.syntaxtree.components.Expression.getBracedExpressionNode;
 import static io.ballerina.protoc.builder.syntaxtree.components.Expression.getFieldAccessExpressionNode;
 import static io.ballerina.protoc.builder.syntaxtree.components.Expression.getMethodCallExpressionNode;
 import static io.ballerina.protoc.builder.syntaxtree.components.Expression.getOptionalFieldAccessExpressionNode;
@@ -263,9 +262,7 @@ public class MessageUtils {
         }
         if (counts.size() > 0) {
             IfElse countCheck = new IfElse(
-                    getBracedExpressionNode(
-                            getCountCheckBinaryExpression(counts)
-                    )
+                    getCountCheckBinaryExpression(counts)
             );
             countCheck.addIfStatement(
                     getReturnStatementNode(

--- a/protoc-cli/src/main/java/io/ballerina/protoc/builder/syntaxtree/utils/ServerUtils.java
+++ b/protoc-cli/src/main/java/io/ballerina/protoc/builder/syntaxtree/utils/ServerUtils.java
@@ -34,7 +34,6 @@ import static io.ballerina.protoc.builder.BallerinaFileBuilder.componentsModuleM
 import static io.ballerina.protoc.builder.BallerinaFileBuilder.protofileModuleMap;
 import static io.ballerina.protoc.builder.balgen.BalGenConstants.COLON;
 import static io.ballerina.protoc.builder.balgen.BalGenConstants.PACKAGE_SEPARATOR;
-import static io.ballerina.protoc.builder.syntaxtree.components.Expression.getBracedExpressionNode;
 import static io.ballerina.protoc.builder.syntaxtree.components.Expression.getExplicitNewExpressionNode;
 import static io.ballerina.protoc.builder.syntaxtree.components.Expression.getFieldAccessExpressionNode;
 import static io.ballerina.protoc.builder.syntaxtree.components.Expression.getMethodCallExpressionNode;
@@ -228,11 +227,9 @@ public class ServerUtils {
         function.addVariableStatement(streamValue.getVariableDeclarationNode());
 
         IfElse streamValueNilCheck = new IfElse(
-                getBracedExpressionNode(
-                        getTypeTestExpressionNode(
-                                getSimpleNameReferenceNode("streamValue"),
-                                getNilTypeDescriptorNode()
-                        )
+                getTypeTestExpressionNode(
+                        getSimpleNameReferenceNode("streamValue"),
+                        getNilTypeDescriptorNode()
                 )
         );
         streamValueNilCheck.addIfStatement(
@@ -241,11 +238,9 @@ public class ServerUtils {
                 )
         );
         IfElse streamValueErrorCheck = new IfElse(
-                getBracedExpressionNode(
-                        getTypeTestExpressionNode(
-                                getSimpleNameReferenceNode("streamValue"),
-                                SyntaxTreeConstants.SYNTAX_TREE_GRPC_ERROR
-                        )
+                getTypeTestExpressionNode(
+                        getSimpleNameReferenceNode("streamValue"),
+                        SyntaxTreeConstants.SYNTAX_TREE_GRPC_ERROR
                 )
         );
         streamValueErrorCheck.addIfStatement(

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_9/helloWorldNestedRepeatedMessages_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_9/helloWorldNestedRepeatedMessages_pb.bal
@@ -135,9 +135,9 @@ public class ResMessageStream {
 
     public isolated function next() returns record {|ResMessage value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|ResMessage value;|} nextRecord = {value: <ResMessage>streamValue.value};

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_9/helloWorldNestedRepeatedMessages_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_9/helloWorldNestedRepeatedMessages_pb_client.bal
@@ -135,9 +135,9 @@ public class ResMessageStream {
 
     public isolated function next() returns record {|ResMessage value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|ResMessage value;|} nextRecord = {value: <ResMessage>streamValue.value};

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_11/oneof_field_service_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_11/oneof_field_service_pb.bal
@@ -185,7 +185,7 @@ isolated function isValidRequest1(Request1 r) returns boolean {
     if r?.'version !is () {
         nameCount += 1;
     }
-    if (otherCount > 1 || nameCount > 1) {
+    if otherCount > 1 || nameCount > 1 {
         return false;
     }
     return true;
@@ -241,7 +241,7 @@ isolated function isValidAddress1(Address1 r) returns boolean {
     if r?.street_number !is () {
         codeCount += 1;
     }
-    if (codeCount > 1) {
+    if codeCount > 1 {
         return false;
     }
     return true;
@@ -318,7 +318,7 @@ isolated function isValidZzz(ZZZ r) returns boolean {
     if r?.one_k !is () {
         valueCount += 1;
     }
-    if (valueCount > 1) {
+    if valueCount > 1 {
         return false;
     }
     return true;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_11/oneof_field_service_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_11/oneof_field_service_pb.bal
@@ -166,23 +166,23 @@ public type Request1 record {|
 
 isolated function isValidRequest1(Request1 r) returns boolean {
     int otherCount = 0;
-    if !(r?.age is ()) {
+    if r?.age !is () {
         otherCount += 1;
     }
-    if !(r?.address is ()) {
+    if r?.address !is () {
         otherCount += 1;
     }
-    if !(r?.married is ()) {
+    if r?.married !is () {
         otherCount += 1;
     }
     int nameCount = 0;
-    if !(r?.first_name is ()) {
+    if r?.first_name !is () {
         nameCount += 1;
     }
-    if !(r?.last_name is ()) {
+    if r?.last_name !is () {
         nameCount += 1;
     }
-    if !(r?.'version is ()) {
+    if r?.'version !is () {
         nameCount += 1;
     }
     if (otherCount > 1 || nameCount > 1) {
@@ -235,10 +235,10 @@ public type Address1 record {|
 
 isolated function isValidAddress1(Address1 r) returns boolean {
     int codeCount = 0;
-    if !(r?.house_number is ()) {
+    if r?.house_number !is () {
         codeCount += 1;
     }
-    if !(r?.street_number is ()) {
+    if r?.street_number !is () {
         codeCount += 1;
     }
     if (codeCount > 1) {
@@ -285,37 +285,37 @@ public type ZZZ record {|
 
 isolated function isValidZzz(ZZZ r) returns boolean {
     int valueCount = 0;
-    if !(r?.one_a is ()) {
+    if r?.one_a !is () {
         valueCount += 1;
     }
-    if !(r?.one_b is ()) {
+    if r?.one_b !is () {
         valueCount += 1;
     }
-    if !(r?.one_c is ()) {
+    if r?.one_c !is () {
         valueCount += 1;
     }
-    if !(r?.one_d is ()) {
+    if r?.one_d !is () {
         valueCount += 1;
     }
-    if !(r?.one_e is ()) {
+    if r?.one_e !is () {
         valueCount += 1;
     }
-    if !(r?.one_f is ()) {
+    if r?.one_f !is () {
         valueCount += 1;
     }
-    if !(r?.one_g is ()) {
+    if r?.one_g !is () {
         valueCount += 1;
     }
-    if !(r?.one_h is ()) {
+    if r?.one_h !is () {
         valueCount += 1;
     }
-    if !(r?.one_i is ()) {
+    if r?.one_i !is () {
         valueCount += 1;
     }
-    if !(r?.one_j is ()) {
+    if r?.one_j !is () {
         valueCount += 1;
     }
-    if !(r?.one_k is ()) {
+    if r?.one_k !is () {
         valueCount += 1;
     }
     if (valueCount > 1) {

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_14/parent_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_14/parent_pb.bal
@@ -135,9 +135,9 @@ public class ParentMessageStream {
 
     public isolated function next() returns record {|ParentMessage value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|ParentMessage value;|} nextRecord = {value: <ParentMessage>streamValue.value};

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_22/duplicate_output_type_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_22/duplicate_output_type_pb.bal
@@ -153,9 +153,9 @@ public class AlbumStream {
 
     public isolated function next() returns record {|Album value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|Album value;|} nextRecord = {value: <Album>streamValue.value};

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_24/empty_message_types_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_24/empty_message_types_pb.bal
@@ -361,9 +361,9 @@ public class EmptyStream {
 
     public isolated function next() returns record {|Empty value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|Empty value;|} nextRecord = {value: <Empty>streamValue.value};

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_9/helloWorldWithReservedNames_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_9/helloWorldWithReservedNames_pb.bal
@@ -161,7 +161,7 @@ public type FieldRules record {|
 
 isolated function isValidFieldrules(FieldRules r) returns boolean {
     int typeCount = 0;
-    if !(r?.'enum is ()) {
+    if r?.'enum !is () {
         typeCount += 1;
     }
     if (typeCount > 1) {

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_9/helloWorldWithReservedNames_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_9/helloWorldWithReservedNames_pb.bal
@@ -164,7 +164,7 @@ isolated function isValidFieldrules(FieldRules r) returns boolean {
     if r?.'enum !is () {
         typeCount += 1;
     }
-    if (typeCount > 1) {
+    if typeCount > 1 {
         return false;
     }
     return true;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_external_imports/parent_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_external_imports/parent_pb.bal
@@ -135,9 +135,9 @@ public class ParentMessageStream {
 
     public isolated function next() returns record {|ParentMessage value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|ParentMessage value;|} nextRecord = {value: <ParentMessage>streamValue.value};

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_2/packageWithMessageImport_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_2/packageWithMessageImport_pb.bal
@@ -158,9 +158,9 @@ public class ResMessageStream {
 
     public isolated function next() returns record {|message:ResMessage value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|message:ResMessage value;|} nextRecord = {value: <message:ResMessage>streamValue.value};

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_2/packageWithMessageImport_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_2/packageWithMessageImport_pb_client.bal
@@ -158,9 +158,9 @@ public class ResMessageStream {
 
     public isolated function next() returns record {|message:ResMessage value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|message:ResMessage value;|} nextRecord = {value: <message:ResMessage>streamValue.value};

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_3/packageWithMultipleImports_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_3/packageWithMultipleImports_pb.bal
@@ -143,9 +143,9 @@ public class ResMessage2Stream {
 
     public isolated function next() returns record {|message2:ResMessage2 value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|message2:ResMessage2 value;|} nextRecord = {value: <message2:ResMessage2>streamValue.value};

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_3/packageWithMultipleImports_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_3/packageWithMultipleImports_pb_client.bal
@@ -143,9 +143,9 @@ public class ResMessage2Stream {
 
     public isolated function next() returns record {|message2:ResMessage2 value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|message2:ResMessage2 value;|} nextRecord = {value: <message2:ResMessage2>streamValue.value};

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_4/modules/message/messageWithService_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_4/modules/message/messageWithService_pb.bal
@@ -135,9 +135,9 @@ public class ResMessageStream {
 
     public isolated function next() returns record {|ResMessage value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|ResMessage value;|} nextRecord = {value: <ResMessage>streamValue.value};

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_5/packageWithNestedSubmodules_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_5/packageWithNestedSubmodules_pb.bal
@@ -143,9 +143,9 @@ public class ResMessageStream {
 
     public isolated function next() returns record {|message2:ResMessage value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|message2:ResMessage value;|} nextRecord = {value: <message2:ResMessage>streamValue.value};

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_5/packageWithNestedSubmodules_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_5/packageWithNestedSubmodules_pb_client.bal
@@ -143,9 +143,9 @@ public class ResMessageStream {
 
     public isolated function next() returns record {|message2:ResMessage value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|message2:ResMessage value;|} nextRecord = {value: <message2:ResMessage>streamValue.value};

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_with_enum_imports/packageWithEnumImports_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_with_enum_imports/packageWithEnumImports_pb.bal
@@ -137,9 +137,9 @@ public class MessageStream {
 
     public isolated function next() returns record {|Message value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|Message value;|} nextRecord = {value: <Message>streamValue.value};

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_with_enum_imports/packageWithEnumImports_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_with_enum_imports/packageWithEnumImports_pb_client.bal
@@ -137,9 +137,9 @@ public class MessageStream {
 
     public isolated function next() returns record {|Message value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|Message value;|} nextRecord = {value: <Message>streamValue.value};

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_6/helloWorldMessage_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_6/helloWorldMessage_pb.bal
@@ -83,9 +83,9 @@ public class HelloResponseStream {
 
     public isolated function next() returns record {|HelloResponse value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|HelloResponse value;|} nextRecord = {value: <HelloResponse>streamValue.value};
@@ -107,9 +107,9 @@ public class ByeResponseStream {
 
     public isolated function next() returns record {|ByeResponse value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|ByeResponse value;|} nextRecord = {value: <ByeResponse>streamValue.value};

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_6/helloWorldMessage_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_6/helloWorldMessage_pb_client.bal
@@ -83,9 +83,9 @@ public class HelloResponseStream {
 
     public isolated function next() returns record {|HelloResponse value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|HelloResponse value;|} nextRecord = {value: <HelloResponse>streamValue.value};
@@ -107,9 +107,9 @@ public class ByeResponseStream {
 
     public isolated function next() returns record {|ByeResponse value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|ByeResponse value;|} nextRecord = {value: <ByeResponse>streamValue.value};

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_7/helloWorldInputEmptyOutputMessage_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_7/helloWorldInputEmptyOutputMessage_pb.bal
@@ -42,9 +42,9 @@ public class HelloResponseStream {
 
     public isolated function next() returns record {|HelloResponse value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|HelloResponse value;|} nextRecord = {value: <HelloResponse>streamValue.value};

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_7/helloWorldInputEmptyOutputMessage_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_7/helloWorldInputEmptyOutputMessage_pb_client.bal
@@ -42,9 +42,9 @@ public class HelloResponseStream {
 
     public isolated function next() returns record {|HelloResponse value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|HelloResponse value;|} nextRecord = {value: <HelloResponse>streamValue.value};

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_8/helloWorldTimestamp_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_8/helloWorldTimestamp_pb.bal
@@ -208,9 +208,9 @@ public class GreetingStream {
 
     public isolated function next() returns record {|Greeting value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|Greeting value;|} nextRecord = {value: <Greeting>streamValue.value};

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_8/helloWorldTimestamp_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_8/helloWorldTimestamp_pb_client.bal
@@ -208,9 +208,9 @@ public class GreetingStream {
 
     public isolated function next() returns record {|Greeting value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|Greeting value;|} nextRecord = {value: <Greeting>streamValue.value};

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_9/dependingService_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_9/dependingService_pb.bal
@@ -53,9 +53,9 @@ public class ResMessageStream {
 
     public isolated function next() returns record {|ResMessage value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|ResMessage value;|} nextRecord = {value: <ResMessage>streamValue.value};

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_9/dependingService_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_9/dependingService_pb_client.bal
@@ -53,9 +53,9 @@ public class ResMessageStream {
 
     public isolated function next() returns record {|ResMessage value;|}|grpc:Error? {
         var streamValue = self.anydataStream.next();
-        if (streamValue is ()) {
+        if streamValue is () {
             return streamValue;
-        } else if (streamValue is grpc:Error) {
+        } else if streamValue is grpc:Error {
             return streamValue;
         } else {
             record {|ResMessage value;|} nextRecord = {value: <ResMessage>streamValue.value};


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/2952
## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
