### PR TITLE
Make caller and streaming client isolated in generated files

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 org.gradle.caching=true
 group=io.ballerina
-version=0.2.1-SNAPSHOT
+version=0.3.0-SNAPSHOT
 #dependency versions
-ballerinaLangVersion=2201.8.0
+ballerinaLangVersion=2201.9.1
 checkstylePluginVersion=10.12.1
 commonsLang3Version=3.8.1
 slf4jVersion=1.7.30
@@ -22,24 +22,24 @@ stdlibTimeVersion=2.4.0
 stdlibUrlVersion=2.4.0
 
 stdlibConstraintVersion=1.4.0
-stdlibCryptoVersion=2.5.0
+stdlibCryptoVersion=2.7.0
 stdlibLogVersion=2.9.0
 stdlibOsVersion=1.8.0
 stdlibProtobufVersion=1.6.0
 stdlibRandomVersion=1.5.0
 stdlibTaskVersion=2.5.0
 
-stdlibCacheVersion=3.7.0
+stdlibCacheVersion=3.8.0
 stdlibFileVersion=1.9.0
 stdlibMimeVersion=2.9.0
-stdlibUuidVersion=1.7.0
+stdlibUuidVersion=1.8.0
 
-stdlibAuthVersion=2.10.0
-stdlibJwtVersion=2.10.0
-stdlibOAuth2Version=2.10.0
+stdlibAuthVersion=2.11.0
+stdlibJwtVersion=2.11.0
+stdlibOAuth2Version=2.11.0
 
-stdlibHttpVersion=2.10.0
+stdlibHttpVersion=2.11.0
 
 # Ballerinax Observer
-observeVersion=1.2.0
-observeInternalVersion=1.2.0
+observeVersion=1.2.3
+observeInternalVersion=1.2.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ researchgateReleaseVersion=2.8.0
 testngVersion=7.6.1
 jacocoVersion=0.8.10
 
-stdlibGrpcVersion=1.10.0
+stdlibGrpcVersion=1.11.1
 stdlibIoVersion=1.6.0
 stdlibTimeVersion=2.4.0
 stdlibUrlVersion=2.4.0
@@ -41,5 +41,5 @@ stdlibOAuth2Version=2.10.0
 stdlibHttpVersion=2.10.0
 
 # Ballerinax Observer
-observeVersion=1.2.0-20230911-133500-b3d8db3
-observeInternalVersion=1.2.0-20230911-141700-4c0454a
+observeVersion=1.2.0
+observeInternalVersion=1.2.0

--- a/protoc-cli/src/main/java/io/ballerina/protoc/builder/syntaxtree/utils/CallerUtils.java
+++ b/protoc-cli/src/main/java/io/ballerina/protoc/builder/syntaxtree/utils/CallerUtils.java
@@ -51,12 +51,12 @@ public class CallerUtils {
 
     public static Class getCallerClass(String key, String value, String filename) {
         Class caller = new Class(key, true);
-        caller.addQualifiers(new String[]{"client"});
+        caller.addQualifiers(new String[]{"isolated", "client"});
 
         caller.addMember(
                 getObjectFieldNode(
                         "private",
-                        new String[]{},
+                        new String[]{"final"},
                         getQualifiedNameReferenceNode("grpc", "Caller"),
                         "caller"
                 )

--- a/protoc-cli/src/main/java/io/ballerina/protoc/builder/syntaxtree/utils/ClientUtils.java
+++ b/protoc-cli/src/main/java/io/ballerina/protoc/builder/syntaxtree/utils/ClientUtils.java
@@ -109,12 +109,12 @@ public class ClientUtils {
         String name = method.getMethodName().substring(0, 1).toUpperCase() + method.getMethodName().substring(1) +
                 STREAMING_CLIENT;
         Class streamingClient = new Class(name, true);
-        streamingClient.addQualifiers(new String[]{"client"});
+        streamingClient.addQualifiers(new String[]{"isolated", "client"});
 
         streamingClient.addMember(
                 getObjectFieldNode(
                         "private",
-                        new String[]{},
+                        new String[]{"final"},
                         getQualifiedNameReferenceNode("grpc", STREAMING_CLIENT),
                         "sClient"));
 

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_1/helloWorldString_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_1/helloWorldString_pb.bal
@@ -19,8 +19,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -63,8 +63,8 @@ public client class HelloStreamingClient {
     }
 }
 
-public client class HelloWorldStringCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldStringCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_1/helloWorldString_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_1/helloWorldString_pb_client.bal
@@ -19,8 +19,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_2/helloWorldInt_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_2/helloWorldInt_pb.bal
@@ -19,8 +19,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -63,8 +63,8 @@ public client class HelloStreamingClient {
     }
 }
 
-public client class HelloWorldIntCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldIntCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_2/helloWorldInt_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_2/helloWorldInt_pb_client.bal
@@ -19,8 +19,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_3/helloWorldFloat_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_3/helloWorldFloat_pb.bal
@@ -19,8 +19,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -63,8 +63,8 @@ public client class HelloStreamingClient {
     }
 }
 
-public client class HelloWorldFloatCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldFloatCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_3/helloWorldFloat_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_3/helloWorldFloat_pb_client.bal
@@ -19,8 +19,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_4/helloWorldBoolean_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_4/helloWorldBoolean_pb.bal
@@ -19,8 +19,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -63,8 +63,8 @@ public client class HelloStreamingClient {
     }
 }
 
-public client class HelloWorldBooleanCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldBooleanCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_4/helloWorldBoolean_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_4/helloWorldBoolean_pb_client.bal
@@ -19,8 +19,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_5/helloWorldBytes_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_5/helloWorldBytes_pb.bal
@@ -19,8 +19,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -63,8 +63,8 @@ public client class HelloStreamingClient {
     }
 }
 
-public client class HelloWorldByteCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldByteCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_5/helloWorldBytes_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_5/helloWorldBytes_pb_client.bal
@@ -19,8 +19,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_6/helloWorldMessage_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_6/helloWorldMessage_pb.bal
@@ -24,8 +24,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -68,8 +68,8 @@ public client class HelloStreamingClient {
     }
 }
 
-public client class ByeStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ByeStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -112,8 +112,8 @@ public client class ByeStreamingClient {
     }
 }
 
-public client class HelloWorldByeResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldByeResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -144,8 +144,8 @@ public client class HelloWorldByeResponseCaller {
     }
 }
 
-public client class HelloWorldHelloResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldHelloResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_6/helloWorldMessage_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_6/helloWorldMessage_pb_client.bal
@@ -24,8 +24,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -68,8 +68,8 @@ public client class HelloStreamingClient {
     }
 }
 
-public client class ByeStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ByeStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_7/helloWorldTimestamp_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_7/helloWorldTimestamp_pb.bal
@@ -47,8 +47,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class GetTimeStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class GetTimeStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -91,8 +91,8 @@ public client class GetTimeStreamingClient {
     }
 }
 
-public client class SendTimeStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class SendTimeStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -135,8 +135,8 @@ public client class SendTimeStreamingClient {
     }
 }
 
-public client class ExchangeTimeStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ExchangeTimeStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -179,8 +179,8 @@ public client class ExchangeTimeStreamingClient {
     }
 }
 
-public client class GetGreetingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class GetGreetingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -223,8 +223,8 @@ public client class GetGreetingStreamingClient {
     }
 }
 
-public client class SendGreetingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class SendGreetingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -267,8 +267,8 @@ public client class SendGreetingStreamingClient {
     }
 }
 
-public client class ExchangeGreetingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ExchangeGreetingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -311,8 +311,8 @@ public client class ExchangeGreetingStreamingClient {
     }
 }
 
-public client class HelloWorldStringCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldStringCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -343,8 +343,8 @@ public client class HelloWorldStringCaller {
     }
 }
 
-public client class HelloWorldGreetingCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldGreetingCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -375,8 +375,8 @@ public client class HelloWorldGreetingCaller {
     }
 }
 
-public client class HelloWorldTimestampCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldTimestampCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_7/helloWorldTimestamp_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_bidirectional_7/helloWorldTimestamp_pb_client.bal
@@ -47,8 +47,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class GetTimeStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class GetTimeStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -91,8 +91,8 @@ public client class GetTimeStreamingClient {
     }
 }
 
-public client class SendTimeStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class SendTimeStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -135,8 +135,8 @@ public client class SendTimeStreamingClient {
     }
 }
 
-public client class ExchangeTimeStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ExchangeTimeStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -179,8 +179,8 @@ public client class ExchangeTimeStreamingClient {
     }
 }
 
-public client class GetGreetingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class GetGreetingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -223,8 +223,8 @@ public client class GetGreetingStreamingClient {
     }
 }
 
-public client class SendGreetingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class SendGreetingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -267,8 +267,8 @@ public client class SendGreetingStreamingClient {
     }
 }
 
-public client class ExchangeGreetingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ExchangeGreetingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_1/helloWorldString_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_1/helloWorldString_pb.bal
@@ -19,8 +19,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -63,8 +63,8 @@ public client class HelloStreamingClient {
     }
 }
 
-public client class HelloWorldStringCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldStringCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_1/helloWorldString_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_1/helloWorldString_pb_client.bal
@@ -19,8 +19,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_2/helloWorldInt_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_2/helloWorldInt_pb.bal
@@ -19,8 +19,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -63,8 +63,8 @@ public client class HelloStreamingClient {
     }
 }
 
-public client class HelloWorldIntCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldIntCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_2/helloWorldInt_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_2/helloWorldInt_pb_client.bal
@@ -19,8 +19,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_3/helloWorldFloat_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_3/helloWorldFloat_pb.bal
@@ -19,8 +19,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -63,8 +63,8 @@ public client class HelloStreamingClient {
     }
 }
 
-public client class HelloWorldFloatCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldFloatCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_3/helloWorldFloat_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_3/helloWorldFloat_pb_client.bal
@@ -19,8 +19,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_4/helloWorldBoolean_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_4/helloWorldBoolean_pb.bal
@@ -19,8 +19,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -63,8 +63,8 @@ public client class HelloStreamingClient {
     }
 }
 
-public client class HelloWorldBooleanCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldBooleanCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_4/helloWorldBoolean_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_4/helloWorldBoolean_pb_client.bal
@@ -19,8 +19,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_5/helloWorldBytes_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_5/helloWorldBytes_pb.bal
@@ -19,8 +19,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -63,8 +63,8 @@ public client class HelloStreamingClient {
     }
 }
 
-public client class HelloWorldByteCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldByteCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_5/helloWorldBytes_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_5/helloWorldBytes_pb_client.bal
@@ -19,8 +19,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_6/helloWorldMessage_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_6/helloWorldMessage_pb.bal
@@ -24,8 +24,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -68,8 +68,8 @@ public client class HelloStreamingClient {
     }
 }
 
-public client class ByeStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ByeStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -112,8 +112,8 @@ public client class ByeStreamingClient {
     }
 }
 
-public client class HelloWorldByeResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldByeResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -144,8 +144,8 @@ public client class HelloWorldByeResponseCaller {
     }
 }
 
-public client class HelloWorldHelloResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldHelloResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_6/helloWorldMessage_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_6/helloWorldMessage_pb_client.bal
@@ -24,8 +24,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -68,8 +68,8 @@ public client class HelloStreamingClient {
     }
 }
 
-public client class ByeStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ByeStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_7/helloWorldInputMessageOutputEmpty_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_7/helloWorldInputMessageOutputEmpty_pb.bal
@@ -20,8 +20,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class TestInputStructNoOutputStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class TestInputStructNoOutputStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -63,8 +63,8 @@ public client class TestInputStructNoOutputStreamingClient {
     }
 }
 
-public client class HelloWorldNilCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldNilCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_7/helloWorldInputMessageOutputEmpty_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_7/helloWorldInputMessageOutputEmpty_pb_client.bal
@@ -20,8 +20,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class TestInputStructNoOutputStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class TestInputStructNoOutputStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_8/helloWorldTimestamp_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_8/helloWorldTimestamp_pb.bal
@@ -47,8 +47,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class GetTimeStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class GetTimeStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -91,8 +91,8 @@ public client class GetTimeStreamingClient {
     }
 }
 
-public client class SendTimeStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class SendTimeStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -135,8 +135,8 @@ public client class SendTimeStreamingClient {
     }
 }
 
-public client class ExchangeTimeStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ExchangeTimeStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -179,8 +179,8 @@ public client class ExchangeTimeStreamingClient {
     }
 }
 
-public client class GetGreetingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class GetGreetingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -223,8 +223,8 @@ public client class GetGreetingStreamingClient {
     }
 }
 
-public client class SendGreetingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class SendGreetingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -267,8 +267,8 @@ public client class SendGreetingStreamingClient {
     }
 }
 
-public client class ExchangeGreetingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ExchangeGreetingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -311,8 +311,8 @@ public client class ExchangeGreetingStreamingClient {
     }
 }
 
-public client class HelloWorldStringCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldStringCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -343,8 +343,8 @@ public client class HelloWorldStringCaller {
     }
 }
 
-public client class HelloWorldGreetingCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldGreetingCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -375,8 +375,8 @@ public client class HelloWorldGreetingCaller {
     }
 }
 
-public client class HelloWorldTimestampCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldTimestampCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_8/helloWorldTimestamp_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_8/helloWorldTimestamp_pb_client.bal
@@ -47,8 +47,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class GetTimeStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class GetTimeStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -91,8 +91,8 @@ public client class GetTimeStreamingClient {
     }
 }
 
-public client class SendTimeStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class SendTimeStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -135,8 +135,8 @@ public client class SendTimeStreamingClient {
     }
 }
 
-public client class ExchangeTimeStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ExchangeTimeStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -179,8 +179,8 @@ public client class ExchangeTimeStreamingClient {
     }
 }
 
-public client class GetGreetingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class GetGreetingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -223,8 +223,8 @@ public client class GetGreetingStreamingClient {
     }
 }
 
-public client class SendGreetingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class SendGreetingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -267,8 +267,8 @@ public client class SendGreetingStreamingClient {
     }
 }
 
-public client class ExchangeGreetingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ExchangeGreetingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_9/helloWorldNestedRepeatedMessages_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_9/helloWorldNestedRepeatedMessages_pb.bal
@@ -82,8 +82,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloWorldStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloWorldStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -150,8 +150,8 @@ public class ResMessageStream {
     }
 }
 
-public client class HelloGrpcStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloGrpcStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -194,8 +194,8 @@ public client class HelloGrpcStreamingClient {
     }
 }
 
-public client class HelloWorldResMessageCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldResMessageCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_9/helloWorldNestedRepeatedMessages_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_client_9/helloWorldNestedRepeatedMessages_pb_client.bal
@@ -82,8 +82,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloWorldStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloWorldStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -150,8 +150,8 @@ public class ResMessageStream {
     }
 }
 
-public client class HelloGrpcStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloGrpcStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_1/helloWorldWithDependency_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_1/helloWorldWithDependency_pb.bal
@@ -70,8 +70,8 @@ public isolated client class helloWorldWithDependencyClient {
     }
 }
 
-public client class HelloWorldWithDependencyHelloResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldWithDependencyHelloResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -102,8 +102,8 @@ public client class HelloWorldWithDependencyHelloResponseCaller {
     }
 }
 
-public client class HelloWorldWithDependencyByeResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldWithDependencyByeResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_11/oneof_field_service_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_11/oneof_field_service_pb.bal
@@ -70,8 +70,8 @@ public isolated client class OneofFieldServiceClient {
     }
 }
 
-public client class OneofFieldServiceZZZCaller {
-    private grpc:Caller caller;
+public isolated client class OneofFieldServiceZZZCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -102,8 +102,8 @@ public client class OneofFieldServiceZZZCaller {
     }
 }
 
-public client class OneofFieldServiceResponse1Caller {
-    private grpc:Caller caller;
+public isolated client class OneofFieldServiceResponse1Caller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_13/helloWorldWithDuplicateInputOutput_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_13/helloWorldWithDuplicateInputOutput_pb.bal
@@ -299,8 +299,8 @@ public isolated client class Chat2Client {
     }
 }
 
-public client class Call5StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Call5StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -343,8 +343,8 @@ public client class Call5StreamingClient {
     }
 }
 
-public client class Call6StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Call6StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -387,8 +387,8 @@ public client class Call6StreamingClient {
     }
 }
 
-public client class Call7StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Call7StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -431,8 +431,8 @@ public client class Call7StreamingClient {
     }
 }
 
-public client class Call8StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Call8StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -475,8 +475,8 @@ public client class Call8StreamingClient {
     }
 }
 
-public client class ChatMsgCaller {
-    private grpc:Caller caller;
+public isolated client class ChatMsgCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -507,8 +507,8 @@ public client class ChatMsgCaller {
     }
 }
 
-public client class ChatStringCaller {
-    private grpc:Caller caller;
+public isolated client class ChatStringCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -539,8 +539,8 @@ public client class ChatStringCaller {
     }
 }
 
-public client class Chat2StringCaller {
-    private grpc:Caller caller;
+public isolated client class Chat2StringCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -571,8 +571,8 @@ public client class Chat2StringCaller {
     }
 }
 
-public client class Chat2MsgCaller {
-    private grpc:Caller caller;
+public isolated client class Chat2MsgCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_14/child_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_14/child_pb.bal
@@ -83,8 +83,8 @@ public isolated client class ChildTestClient {
     }
 }
 
-public client class CallChild2StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class CallChild2StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -127,8 +127,8 @@ public client class CallChild2StreamingClient {
     }
 }
 
-public client class CallChild4StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class CallChild4StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -171,8 +171,8 @@ public client class CallChild4StreamingClient {
     }
 }
 
-public client class ChildTestChildMessageCaller {
-    private grpc:Caller caller;
+public isolated client class ChildTestChildMessageCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -203,8 +203,8 @@ public client class ChildTestChildMessageCaller {
     }
 }
 
-public client class ChildTestParentMessageCaller {
-    private grpc:Caller caller;
+public isolated client class ChildTestParentMessageCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_14/parent_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_14/parent_pb.bal
@@ -82,8 +82,8 @@ public isolated client class ParentTestClient {
     }
 }
 
-public client class CallParent2StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class CallParent2StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -150,8 +150,8 @@ public class ParentMessageStream {
     }
 }
 
-public client class CallParent4StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class CallParent4StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -194,8 +194,8 @@ public client class CallParent4StreamingClient {
     }
 }
 
-public client class ParentTestParentMessageCaller {
-    private grpc:Caller caller;
+public isolated client class ParentTestParentMessageCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_15/duration_type1_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_15/duration_type1_pb.bal
@@ -114,8 +114,8 @@ public isolated client class DurationHandlerClient {
     }
 }
 
-public client class ClientStreamingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ClientStreamingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -158,8 +158,8 @@ public client class ClientStreamingStreamingClient {
     }
 }
 
-public client class BidirectionalStreamingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class BidirectionalStreamingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -202,8 +202,8 @@ public client class BidirectionalStreamingStreamingClient {
     }
 }
 
-public client class DurationHandlerDurationMsgCaller {
-    private grpc:Caller caller;
+public isolated client class DurationHandlerDurationMsgCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -234,8 +234,8 @@ public client class DurationHandlerDurationMsgCaller {
     }
 }
 
-public client class DurationHandlerDurationCaller {
-    private grpc:Caller caller;
+public isolated client class DurationHandlerDurationCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -266,8 +266,8 @@ public client class DurationHandlerDurationCaller {
     }
 }
 
-public client class DurationHandlerStringCaller {
-    private grpc:Caller caller;
+public isolated client class DurationHandlerStringCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_15/duration_type1_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_15/duration_type1_pb_client.bal
@@ -114,8 +114,8 @@ public isolated client class DurationHandlerClient {
     }
 }
 
-public client class ClientStreamingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ClientStreamingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -158,8 +158,8 @@ public client class ClientStreamingStreamingClient {
     }
 }
 
-public client class BidirectionalStreamingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class BidirectionalStreamingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_16/duration_type2_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_16/duration_type2_pb.bal
@@ -84,8 +84,8 @@ public isolated client class DurationHandlerClient {
     }
 }
 
-public client class ClientStreamingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ClientStreamingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -128,8 +128,8 @@ public client class ClientStreamingStreamingClient {
     }
 }
 
-public client class BidirectionalStreamingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class BidirectionalStreamingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -172,8 +172,8 @@ public client class BidirectionalStreamingStreamingClient {
     }
 }
 
-public client class DurationHandlerDurationCaller {
-    private grpc:Caller caller;
+public isolated client class DurationHandlerDurationCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_16/duration_type2_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_16/duration_type2_pb_client.bal
@@ -84,8 +84,8 @@ public isolated client class DurationHandlerClient {
     }
 }
 
-public client class ClientStreamingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ClientStreamingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -128,8 +128,8 @@ public client class ClientStreamingStreamingClient {
     }
 }
 
-public client class BidirectionalStreamingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class BidirectionalStreamingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_17/struct_type1_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_17/struct_type1_pb.bal
@@ -113,8 +113,8 @@ public isolated client class StructHandlerClient {
     }
 }
 
-public client class ClientStreamingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ClientStreamingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -157,8 +157,8 @@ public client class ClientStreamingStreamingClient {
     }
 }
 
-public client class BidirectionalStreamingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class BidirectionalStreamingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -201,8 +201,8 @@ public client class BidirectionalStreamingStreamingClient {
     }
 }
 
-public client class StructHandlerStringCaller {
-    private grpc:Caller caller;
+public isolated client class StructHandlerStringCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -233,8 +233,8 @@ public client class StructHandlerStringCaller {
     }
 }
 
-public client class StructHandlerStructCaller {
-    private grpc:Caller caller;
+public isolated client class StructHandlerStructCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -265,8 +265,8 @@ public client class StructHandlerStructCaller {
     }
 }
 
-public client class StructHandlerStructMsgCaller {
-    private grpc:Caller caller;
+public isolated client class StructHandlerStructMsgCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_17/struct_type1_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_17/struct_type1_pb_client.bal
@@ -113,8 +113,8 @@ public isolated client class StructHandlerClient {
     }
 }
 
-public client class ClientStreamingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ClientStreamingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -157,8 +157,8 @@ public client class ClientStreamingStreamingClient {
     }
 }
 
-public client class BidirectionalStreamingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class BidirectionalStreamingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_18/struct_type2_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_18/struct_type2_pb.bal
@@ -83,8 +83,8 @@ public isolated client class StructHandlerClient {
     }
 }
 
-public client class ClientStreamingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ClientStreamingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -127,8 +127,8 @@ public client class ClientStreamingStreamingClient {
     }
 }
 
-public client class BidirectionalStreamingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class BidirectionalStreamingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -171,8 +171,8 @@ public client class BidirectionalStreamingStreamingClient {
     }
 }
 
-public client class StructHandlerStructCaller {
-    private grpc:Caller caller;
+public isolated client class StructHandlerStructCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_18/struct_type2_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_18/struct_type2_pb_client.bal
@@ -83,8 +83,8 @@ public isolated client class StructHandlerClient {
     }
 }
 
-public client class ClientStreamingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ClientStreamingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -127,8 +127,8 @@ public client class ClientStreamingStreamingClient {
     }
 }
 
-public client class BidirectionalStreamingStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class BidirectionalStreamingStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_19/time_root_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_19/time_root_pb.bal
@@ -21,8 +21,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class SendTimeStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class SendTimeStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -65,8 +65,8 @@ public client class SendTimeStreamingClient {
     }
 }
 
-public client class HelloWorldGreetingCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldGreetingCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_20/multiple_wrapper_types_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_20/multiple_wrapper_types_pb.bal
@@ -236,8 +236,8 @@ public isolated client class HelloWorld3Client {
     }
 }
 
-public client class HelloWorld3FloatCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorld3FloatCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -268,8 +268,8 @@ public client class HelloWorld3FloatCaller {
     }
 }
 
-public client class HelloWorld3IntCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorld3IntCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -300,8 +300,8 @@ public client class HelloWorld3IntCaller {
     }
 }
 
-public client class HelloWorld3TestFloatCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorld3TestFloatCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -332,8 +332,8 @@ public client class HelloWorld3TestFloatCaller {
     }
 }
 
-public client class HelloWorld3TestBooleanCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorld3TestBooleanCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -364,8 +364,8 @@ public client class HelloWorld3TestBooleanCaller {
     }
 }
 
-public client class HelloWorld3BooleanCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorld3BooleanCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -396,8 +396,8 @@ public client class HelloWorld3BooleanCaller {
     }
 }
 
-public client class HelloWorld3TestIntCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorld3TestIntCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -428,8 +428,8 @@ public client class HelloWorld3TestIntCaller {
     }
 }
 
-public client class HelloWorld3StringCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorld3StringCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -460,8 +460,8 @@ public client class HelloWorld3StringCaller {
     }
 }
 
-public client class HelloWorld3TestStructCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorld3TestStructCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -492,8 +492,8 @@ public client class HelloWorld3TestStructCaller {
     }
 }
 
-public client class HelloWorld3TestStringCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorld3TestStringCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_21/any_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_21/any_pb.bal
@@ -140,8 +140,8 @@ public isolated client class AnyTypeServerClient {
     }
 }
 
-public client class ClientStreamingCallStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ClientStreamingCallStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -184,8 +184,8 @@ public client class ClientStreamingCallStreamingClient {
     }
 }
 
-public client class BidirectionalStreamingCallStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class BidirectionalStreamingCallStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -228,8 +228,8 @@ public client class BidirectionalStreamingCallStreamingClient {
     }
 }
 
-public client class AnyTypeServerAnyCaller {
-    private grpc:Caller caller;
+public isolated client class AnyTypeServerAnyCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_21/any_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_21/any_pb_client.bal
@@ -140,8 +140,8 @@ public isolated client class AnyTypeServerClient {
     }
 }
 
-public client class ClientStreamingCallStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ClientStreamingCallStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -184,8 +184,8 @@ public client class ClientStreamingCallStreamingClient {
     }
 }
 
-public client class BidirectionalStreamingCallStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class BidirectionalStreamingCallStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_22/duplicate_output_type_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_22/duplicate_output_type_pb.bal
@@ -100,8 +100,8 @@ public isolated client class RecordStoreClient {
     }
 }
 
-public client class GetTotalValueStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class GetTotalValueStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -168,8 +168,8 @@ public class AlbumStream {
     }
 }
 
-public client class UpdateAlbumsStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class UpdateAlbumsStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -212,8 +212,8 @@ public client class UpdateAlbumsStreamingClient {
     }
 }
 
-public client class RecordStoreIntCaller {
-    private grpc:Caller caller;
+public isolated client class RecordStoreIntCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -244,8 +244,8 @@ public client class RecordStoreIntCaller {
     }
 }
 
-public client class RecordStoreAlbumCaller {
-    private grpc:Caller caller;
+public isolated client class RecordStoreAlbumCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_23/enumWithReservedNames_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_23/enumWithReservedNames_pb.bal
@@ -42,8 +42,8 @@ public isolated client class MessageServiceClient {
     }
 }
 
-public client class MessageServiceMessageStateCaller {
-    private grpc:Caller caller;
+public isolated client class MessageServiceMessageStateCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_24/empty_message_types_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_24/empty_message_types_pb.bal
@@ -264,8 +264,8 @@ public isolated client class ServiceWithPredefinedNamesClient {
     }
 }
 
-public client class ClientCallEmptyInputStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ClientCallEmptyInputStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -308,8 +308,8 @@ public client class ClientCallEmptyInputStreamingClient {
     }
 }
 
-public client class ClientCallEmptyOutputStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ClientCallEmptyOutputStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -376,8 +376,8 @@ public class EmptyStream {
     }
 }
 
-public client class BidiCallEmptyInputStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class BidiCallEmptyInputStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -420,8 +420,8 @@ public client class BidiCallEmptyInputStreamingClient {
     }
 }
 
-public client class BidiCallEmptyOutputStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class BidiCallEmptyOutputStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -464,8 +464,8 @@ public client class BidiCallEmptyOutputStreamingClient {
     }
 }
 
-public client class ServiceWithPredefinedNamesTimestampCaller {
-    private grpc:Caller caller;
+public isolated client class ServiceWithPredefinedNamesTimestampCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -496,8 +496,8 @@ public client class ServiceWithPredefinedNamesTimestampCaller {
     }
 }
 
-public client class ServiceWithPredefinedNamesAnyCaller {
-    private grpc:Caller caller;
+public isolated client class ServiceWithPredefinedNamesAnyCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -528,8 +528,8 @@ public client class ServiceWithPredefinedNamesAnyCaller {
     }
 }
 
-public client class ServiceWithPredefinedNamesStringCaller {
-    private grpc:Caller caller;
+public isolated client class ServiceWithPredefinedNamesStringCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -560,8 +560,8 @@ public client class ServiceWithPredefinedNamesStringCaller {
     }
 }
 
-public client class ServiceWithPredefinedNamesStructCaller {
-    private grpc:Caller caller;
+public isolated client class ServiceWithPredefinedNamesStructCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -592,8 +592,8 @@ public client class ServiceWithPredefinedNamesStructCaller {
     }
 }
 
-public client class ServiceWithPredefinedNamesDurationCaller {
-    private grpc:Caller caller;
+public isolated client class ServiceWithPredefinedNamesDurationCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -624,8 +624,8 @@ public client class ServiceWithPredefinedNamesDurationCaller {
     }
 }
 
-public client class ServiceWithPredefinedNamesEmptyCaller {
-    private grpc:Caller caller;
+public isolated client class ServiceWithPredefinedNamesEmptyCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_25/service_with_nested_messages_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_25/service_with_nested_messages_pb.bal
@@ -42,8 +42,8 @@ public isolated client class ServiceWithNestedMessageClient {
     }
 }
 
-public client class ServiceWithNestedMessageNestedResponseMessageCaller {
-    private grpc:Caller caller;
+public isolated client class ServiceWithNestedMessageNestedResponseMessageCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_26/child_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_26/child_pb.bal
@@ -43,8 +43,8 @@ public isolated client class HelloWorldClient {
     }
 }
 
-public client class HelloWorldHelloCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldHelloCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_3/helloWorldWithEnum_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_3/helloWorldWithEnum_pb.bal
@@ -70,8 +70,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloWorldByeResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldByeResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -102,8 +102,8 @@ public client class HelloWorldByeResponseCaller {
     }
 }
 
-public client class HelloWorldHelloResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldHelloResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_5/helloWorldWithMap_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_5/helloWorldWithMap_pb.bal
@@ -42,8 +42,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloWorldHelloResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldHelloResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_6/helloWorldWithNestedEnum_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_6/helloWorldWithNestedEnum_pb.bal
@@ -137,8 +137,8 @@ public isolated client class helloFooWithNestedEnumClient {
     }
 }
 
-public client class HelloWorldWithNestedEnumByeResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldWithNestedEnumByeResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -169,8 +169,8 @@ public client class HelloWorldWithNestedEnumByeResponseCaller {
     }
 }
 
-public client class HelloWorldWithNestedEnumHelloResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldWithNestedEnumHelloResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -201,8 +201,8 @@ public client class HelloWorldWithNestedEnumHelloResponseCaller {
     }
 }
 
-public client class HelloFooWithNestedEnumHelloResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloFooWithNestedEnumHelloResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -233,8 +233,8 @@ public client class HelloFooWithNestedEnumHelloResponseCaller {
     }
 }
 
-public client class HelloFooWithNestedEnumByeResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloFooWithNestedEnumByeResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_7/helloWorldWithNestedMessage_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_7/helloWorldWithNestedMessage_pb.bal
@@ -70,8 +70,8 @@ public isolated client class helloWorldWithNestedMessageClient {
     }
 }
 
-public client class HelloWorldWithNestedMessageHelloResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldWithNestedMessageHelloResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -102,8 +102,8 @@ public client class HelloWorldWithNestedMessageHelloResponseCaller {
     }
 }
 
-public client class HelloWorldWithNestedMessageByeResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldWithNestedMessageByeResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_8/helloWorldWithPackage_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_8/helloWorldWithPackage_pb.bal
@@ -70,8 +70,8 @@ public isolated client class helloWorldWithPackageClient {
     }
 }
 
-public client class HelloWorldWithPackageByeResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldWithPackageByeResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -102,8 +102,8 @@ public client class HelloWorldWithPackageByeResponseCaller {
     }
 }
 
-public client class HelloWorldWithPackageHelloResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldWithPackageHelloResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_9/helloWorldWithReservedNames_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_data_type_9/helloWorldWithReservedNames_pb.bal
@@ -70,8 +70,8 @@ public isolated client class helloWorldWithReservedNamesClient {
     }
 }
 
-public client class HelloWorldWithReservedNamesHelloResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldWithReservedNamesHelloResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -102,8 +102,8 @@ public client class HelloWorldWithReservedNamesHelloResponseCaller {
     }
 }
 
-public client class HelloWorldWithReservedNamesByeResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldWithReservedNamesByeResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_external_imports/child_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_external_imports/child_pb.bal
@@ -112,8 +112,8 @@ public isolated client class ChildTestClient {
     }
 }
 
-public client class CallChild2StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class CallChild2StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -156,8 +156,8 @@ public client class CallChild2StreamingClient {
     }
 }
 
-public client class CallChild4StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class CallChild4StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -200,8 +200,8 @@ public client class CallChild4StreamingClient {
     }
 }
 
-public client class ChildTestChildMessageCaller {
-    private grpc:Caller caller;
+public isolated client class ChildTestChildMessageCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -232,8 +232,8 @@ public client class ChildTestChildMessageCaller {
     }
 }
 
-public client class ChildTestParentMessageCaller {
-    private grpc:Caller caller;
+public isolated client class ChildTestParentMessageCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_external_imports/parent_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_external_imports/parent_pb.bal
@@ -82,8 +82,8 @@ public isolated client class ParentTestClient {
     }
 }
 
-public client class CallParent2StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class CallParent2StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -150,8 +150,8 @@ public class ParentMessageStream {
     }
 }
 
-public client class CallParent4StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class CallParent4StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -194,8 +194,8 @@ public client class CallParent4StreamingClient {
     }
 }
 
-public client class ParentTestParentMessageCaller {
-    private grpc:Caller caller;
+public isolated client class ParentTestParentMessageCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_nested_directories_01/service_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_nested_directories_01/service_pb.bal
@@ -42,8 +42,8 @@ public isolated client class MyServiceClient {
     }
 }
 
-public client class MyServiceMainMessageCaller {
-    private grpc:Caller caller;
+public isolated client class MyServiceMainMessageCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_nested_directories_02/service_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_nested_directories_02/service_pb.bal
@@ -71,8 +71,8 @@ public isolated client class MyServiceClient {
     }
 }
 
-public client class MyServiceMessage2Caller {
-    private grpc:Caller caller;
+public isolated client class MyServiceMessage2Caller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -103,8 +103,8 @@ public client class MyServiceMessage2Caller {
     }
 }
 
-public client class MyServiceMainMessageCaller {
-    private grpc:Caller caller;
+public isolated client class MyServiceMainMessageCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_nested_directories_03/service1_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_nested_directories_03/service1_pb.bal
@@ -71,8 +71,8 @@ public isolated client class MyService1Client {
     }
 }
 
-public client class MyService1MainMessage1Caller {
-    private grpc:Caller caller;
+public isolated client class MyService1MainMessage1Caller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -103,8 +103,8 @@ public client class MyService1MainMessage1Caller {
     }
 }
 
-public client class MyService1Message2Caller {
-    private grpc:Caller caller;
+public isolated client class MyService1Message2Caller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_nested_directories_03/service2_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_nested_directories_03/service2_pb.bal
@@ -71,8 +71,8 @@ public isolated client class MyService2Client {
     }
 }
 
-public client class MyService2Message1Caller {
-    private grpc:Caller caller;
+public isolated client class MyService2Message1Caller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -103,8 +103,8 @@ public client class MyService2Message1Caller {
     }
 }
 
-public client class MyService2MainMessage2Caller {
-    private grpc:Caller caller;
+public isolated client class MyService2MainMessage2Caller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_1/simplePackage_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_1/simplePackage_pb.bal
@@ -71,8 +71,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloWorldHelloResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldHelloResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -103,8 +103,8 @@ public client class HelloWorldHelloResponseCaller {
     }
 }
 
-public client class HelloWorldBooleanCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldBooleanCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_2/packageWithMessageImport_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_2/packageWithMessageImport_pb.bal
@@ -105,8 +105,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class Hello3StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello3StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -173,8 +173,8 @@ public class ResMessageStream {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -217,8 +217,8 @@ public client class HelloStreamingClient {
     }
 }
 
-public client class Hello4StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello4StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -261,8 +261,8 @@ public client class Hello4StreamingClient {
     }
 }
 
-public client class Hello5StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello5StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -305,8 +305,8 @@ public client class Hello5StreamingClient {
     }
 }
 
-public client class Hello10StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello10StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -349,8 +349,8 @@ public client class Hello10StreamingClient {
     }
 }
 
-public client class Hello11StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello11StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -393,8 +393,8 @@ public client class Hello11StreamingClient {
     }
 }
 
-public client class HelloWorldRootMessageCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldRootMessageCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -425,8 +425,8 @@ public client class HelloWorldRootMessageCaller {
     }
 }
 
-public client class HelloWorldResMessageCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldResMessageCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -457,8 +457,8 @@ public client class HelloWorldResMessageCaller {
     }
 }
 
-public client class HelloWorldBooleanCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldBooleanCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_2/packageWithMessageImport_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_2/packageWithMessageImport_pb_client.bal
@@ -105,8 +105,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class Hello3StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello3StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -173,8 +173,8 @@ public class ResMessageStream {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -217,8 +217,8 @@ public client class HelloStreamingClient {
     }
 }
 
-public client class Hello4StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello4StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -261,8 +261,8 @@ public client class Hello4StreamingClient {
     }
 }
 
-public client class Hello5StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello5StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -305,8 +305,8 @@ public client class Hello5StreamingClient {
     }
 }
 
-public client class Hello10StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello10StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -349,8 +349,8 @@ public client class Hello10StreamingClient {
     }
 }
 
-public client class Hello11StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello11StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_3/packageWithMultipleImports_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_3/packageWithMultipleImports_pb.bal
@@ -90,8 +90,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class Hello3StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello3StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -158,8 +158,8 @@ public class ResMessage2Stream {
     }
 }
 
-public client class Hello4StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello4StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -202,8 +202,8 @@ public client class Hello4StreamingClient {
     }
 }
 
-public client class Hello5StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello5StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -246,8 +246,8 @@ public client class Hello5StreamingClient {
     }
 }
 
-public client class HelloWorldRootMessageCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldRootMessageCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -278,8 +278,8 @@ public client class HelloWorldRootMessageCaller {
     }
 }
 
-public client class HelloWorldResMessage2Caller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldResMessage2Caller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_3/packageWithMultipleImports_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_3/packageWithMultipleImports_pb_client.bal
@@ -90,8 +90,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class Hello3StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello3StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -158,8 +158,8 @@ public class ResMessage2Stream {
     }
 }
 
-public client class Hello4StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello4StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -202,8 +202,8 @@ public client class Hello4StreamingClient {
     }
 }
 
-public client class Hello5StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello5StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_4/modules/message/messageWithService_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_4/modules/message/messageWithService_pb.bal
@@ -82,8 +82,8 @@ public isolated client class helloBallerinaClient {
     }
 }
 
-public client class HelloStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class HelloStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -150,8 +150,8 @@ public class ResMessageStream {
     }
 }
 
-public client class ByeStreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class ByeStreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -194,8 +194,8 @@ public client class ByeStreamingClient {
     }
 }
 
-public client class HelloBallerinaResMessageCaller {
-    private grpc:Caller caller;
+public isolated client class HelloBallerinaResMessageCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_4/packageWithImportContainingService_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_4/packageWithImportContainingService_pb.bal
@@ -89,8 +89,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class Hello3StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello3StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -133,8 +133,8 @@ public client class Hello3StreamingClient {
     }
 }
 
-public client class Hello4StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello4StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -177,8 +177,8 @@ public client class Hello4StreamingClient {
     }
 }
 
-public client class Hello5StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello5StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -221,8 +221,8 @@ public client class Hello5StreamingClient {
     }
 }
 
-public client class HelloWorldRootMessageCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldRootMessageCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -253,8 +253,8 @@ public client class HelloWorldRootMessageCaller {
     }
 }
 
-public client class HelloWorldResMessageCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldResMessageCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_4/packageWithImportContainingService_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_4/packageWithImportContainingService_pb_client.bal
@@ -90,8 +90,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class Hello3StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello3StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -134,8 +134,8 @@ public client class Hello3StreamingClient {
     }
 }
 
-public client class Hello4StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello4StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -178,8 +178,8 @@ public client class Hello4StreamingClient {
     }
 }
 
-public client class Hello5StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello5StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_5/packageWithNestedSubmodules_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_5/packageWithNestedSubmodules_pb.bal
@@ -90,8 +90,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class Hello3StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello3StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -158,8 +158,8 @@ public class ResMessageStream {
     }
 }
 
-public client class Hello4StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello4StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -202,8 +202,8 @@ public client class Hello4StreamingClient {
     }
 }
 
-public client class Hello5StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello5StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -246,8 +246,8 @@ public client class Hello5StreamingClient {
     }
 }
 
-public client class HelloWorldRootMessageCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldRootMessageCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -278,8 +278,8 @@ public client class HelloWorldRootMessageCaller {
     }
 }
 
-public client class HelloWorldResMessageCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldResMessageCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_5/packageWithNestedSubmodules_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_5/packageWithNestedSubmodules_pb_client.bal
@@ -90,8 +90,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class Hello3StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello3StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -158,8 +158,8 @@ public class ResMessageStream {
     }
 }
 
-public client class Hello4StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello4StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -202,8 +202,8 @@ public client class Hello4StreamingClient {
     }
 }
 
-public client class Hello5StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello5StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_nested_dirs/service1_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_nested_dirs/service1_pb.bal
@@ -72,8 +72,8 @@ public isolated client class MyService1Client {
     }
 }
 
-public client class MyService1MainMessage1Caller {
-    private grpc:Caller caller;
+public isolated client class MyService1MainMessage1Caller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -104,8 +104,8 @@ public client class MyService1MainMessage1Caller {
     }
 }
 
-public client class MyService1Message2Caller {
-    private grpc:Caller caller;
+public isolated client class MyService1Message2Caller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_nested_dirs/service2_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_nested_dirs/service2_pb.bal
@@ -72,8 +72,8 @@ public isolated client class MyService2Client {
     }
 }
 
-public client class MyService2Message1Caller {
-    private grpc:Caller caller;
+public isolated client class MyService2Message1Caller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -104,8 +104,8 @@ public client class MyService2Message1Caller {
     }
 }
 
-public client class MyService2MainMessage2Caller {
-    private grpc:Caller caller;
+public isolated client class MyService2MainMessage2Caller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_with_enum_imports/packageWithEnumImports_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_with_enum_imports/packageWithEnumImports_pb.bal
@@ -84,8 +84,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class Hello3StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello3StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -152,8 +152,8 @@ public class MessageStream {
     }
 }
 
-public client class Hello4StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello4StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -196,8 +196,8 @@ public client class Hello4StreamingClient {
     }
 }
 
-public client class HelloWorldMessageCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldMessageCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_with_enum_imports/packageWithEnumImports_pb_client.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_packaging_with_enum_imports/packageWithEnumImports_pb_client.bal
@@ -84,8 +84,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class Hello3StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello3StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;
@@ -152,8 +152,8 @@ public class MessageStream {
     }
 }
 
-public client class Hello4StreamingClient {
-    private grpc:StreamingClient sClient;
+public isolated client class Hello4StreamingClient {
+    private final grpc:StreamingClient sClient;
 
     isolated function init(grpc:StreamingClient sClient) {
         self.sClient = sClient;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_proto_dir/helloWorldBoolean_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_proto_dir/helloWorldBoolean_pb.bal
@@ -42,8 +42,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloWorldBooleanCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldBooleanCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_proto_dir/helloWorldInt_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_proto_dir/helloWorldInt_pb.bal
@@ -42,8 +42,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloWorldIntCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldIntCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_proto_dir/helloWorldString_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_proto_dir/helloWorldString_pb.bal
@@ -42,8 +42,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloWorldStringCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldStringCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_proto_dir/helloWorldWithDependency_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_proto_dir/helloWorldWithDependency_pb.bal
@@ -42,8 +42,8 @@ public isolated client class helloWorldWithDependencyClient {
     }
 }
 
-public client class HelloWorldWithDependencyHelloResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldWithDependencyHelloResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_1/helloWorldString_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_1/helloWorldString_pb.bal
@@ -45,8 +45,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloWorldStringCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldStringCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_2/helloWorldInt_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_2/helloWorldInt_pb.bal
@@ -45,8 +45,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloWorldIntCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldIntCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_3/helloWorldFloat_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_3/helloWorldFloat_pb.bal
@@ -45,8 +45,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloWorldFloatCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldFloatCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_4/helloWorldBoolean_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_4/helloWorldBoolean_pb.bal
@@ -45,8 +45,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloWorldBooleanCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldBooleanCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_5/helloWorldBytes_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_5/helloWorldBytes_pb.bal
@@ -45,8 +45,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloWorldByteCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldByteCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_6/helloWorldMessage_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_6/helloWorldMessage_pb.bal
@@ -122,8 +122,8 @@ public class ByeResponseStream {
     }
 }
 
-public client class HelloWorldByeResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldByeResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -154,8 +154,8 @@ public client class HelloWorldByeResponseCaller {
     }
 }
 
-public client class HelloWorldHelloResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldHelloResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_7/helloWorldInputEmptyOutputMessage_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_7/helloWorldInputEmptyOutputMessage_pb.bal
@@ -57,8 +57,8 @@ public class HelloResponseStream {
     }
 }
 
-public client class HelloWorldHelloResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldHelloResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_8/helloWorldTimestamp_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_8/helloWorldTimestamp_pb.bal
@@ -223,8 +223,8 @@ public class GreetingStream {
     }
 }
 
-public client class HelloWorldStringCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldStringCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -255,8 +255,8 @@ public client class HelloWorldStringCaller {
     }
 }
 
-public client class HelloWorldGreetingCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldGreetingCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -287,8 +287,8 @@ public client class HelloWorldGreetingCaller {
     }
 }
 
-public client class HelloWorldTimestampCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldTimestampCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_9/dependingService_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_9/dependingService_pb.bal
@@ -68,8 +68,8 @@ public class ResMessageStream {
     }
 }
 
-public client class HelloWorldResMessageCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldResMessageCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_9/helloService_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_server_9/helloService_pb.bal
@@ -42,8 +42,8 @@ public isolated client class helloBallerinaClient {
     }
 }
 
-public client class HelloBallerinaResMessageCaller {
-    private grpc:Caller caller;
+public isolated client class HelloBallerinaResMessageCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_unary_1/helloWorldString_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_unary_1/helloWorldString_pb.bal
@@ -42,8 +42,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloWorldStringCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldStringCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_unary_10/helloWorldTimestamp_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_unary_10/helloWorldTimestamp_pb.bal
@@ -185,8 +185,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloWorldStringCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldStringCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -217,8 +217,8 @@ public client class HelloWorldStringCaller {
     }
 }
 
-public client class HelloWorldGreetingCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldGreetingCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -249,8 +249,8 @@ public client class HelloWorldGreetingCaller {
     }
 }
 
-public client class HelloWorldTimestampCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldTimestampCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_unary_2/helloWorldInt_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_unary_2/helloWorldInt_pb.bal
@@ -42,8 +42,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloWorldIntCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldIntCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_unary_3/helloWorldFloat_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_unary_3/helloWorldFloat_pb.bal
@@ -42,8 +42,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloWorldFloatCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldFloatCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_unary_4/helloWorldBoolean_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_unary_4/helloWorldBoolean_pb.bal
@@ -42,8 +42,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloWorldBooleanCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldBooleanCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_unary_5/helloWorldBytes_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_unary_5/helloWorldBytes_pb.bal
@@ -42,8 +42,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloWorldByteCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldByteCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_unary_6/helloWorldMessage_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_unary_6/helloWorldMessage_pb.bal
@@ -70,8 +70,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloWorldByeResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldByeResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;
@@ -102,8 +102,8 @@ public client class HelloWorldByeResponseCaller {
     }
 }
 
-public client class HelloWorldHelloResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldHelloResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_unary_7/helloWorldInputEmptyOutputMessage_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_unary_7/helloWorldInputEmptyOutputMessage_pb.bal
@@ -31,8 +31,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloWorldHelloResponseCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldHelloResponseCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;

--- a/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_unary_8/helloWorldInputMessageOutputEmpty_pb.bal
+++ b/tooling-tests/src/test/resources/test-src/generated-sources/tool_test_unary_8/helloWorldInputMessageOutputEmpty_pb.bal
@@ -41,8 +41,8 @@ public isolated client class helloWorldClient {
     }
 }
 
-public client class HelloWorldNilCaller {
-    private grpc:Caller caller;
+public isolated client class HelloWorldNilCaller {
+    private final grpc:Caller caller;
 
     public isolated function init(grpc:Caller caller) {
         self.caller = caller;


### PR DESCRIPTION
## Purpose
Related to https://github.com/ballerina-platform/ballerina-library/issues/6656

This will fail until this PR is merged and a patch is released - https://github.com/ballerina-platform/module-ballerina-grpc/pull/1614
## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
