### PR TITLE
Use `getValue()` instead of directly accessing `Name.value`

### DIFF
--- a/protoc-cli/src/main/java/io/ballerina/protoc/builder/stub/Field.java
+++ b/protoc-cli/src/main/java/io/ballerina/protoc/builder/stub/Field.java
@@ -120,7 +120,7 @@ public class Field {
                 fieldDefaultValue = fieldLabel;
             }
             String fieldName = fieldDescriptor.getName();
-            if (Arrays.stream(RESERVED_LITERAL_NAMES).anyMatch(fieldName::equalsIgnoreCase) || Names.ERROR.value
+            if (Arrays.stream(RESERVED_LITERAL_NAMES).anyMatch(fieldName::equalsIgnoreCase) || Names.ERROR.getValue()
                     .equalsIgnoreCase(fieldName)) {
                 fieldName = "'" + fieldName;
             }


### PR DESCRIPTION
## Purpose
Part of https://github.com/ballerina-platform/ballerina-lang/pull/43265
## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
