### PR TITLE
Fix extra line in generated ballerina source in grpc tool

### DIFF
--- a/protoc-cli/src/main/java/io/ballerina/protoc/builder/BallerinaFileBuilder.java
+++ b/protoc-cli/src/main/java/io/ballerina/protoc/builder/BallerinaFileBuilder.java
@@ -396,7 +396,7 @@ public class BallerinaFileBuilder {
             throw new CodeBuilderException("Formatter Error while formatting output source code. " + e.getMessage(), e);
         }
         try (PrintWriter writer = new PrintWriter(outPath, StandardCharsets.UTF_8.name())) {
-            writer.println(content);
+            writer.print(content); 
         } catch (IOException e) {
             throw new CodeBuilderException("IO Error while writing output to Ballerina file. " + e.getMessage(), e);
         }

--- a/tooling-tests/src/test/java/io/ballerina/protoc/tools/ToolingCommonTest.java
+++ b/tooling-tests/src/test/java/io/ballerina/protoc/tools/ToolingCommonTest.java
@@ -347,4 +347,39 @@ public class ToolingCommonTest {
         assertGeneratedSources("data-types/enum_imports", "child.proto",
                 "child_pb.bal", "helloworld_service.bal", "helloworld_client.bal", "tool_test_data_type_26");
     }
+
+    @Test
+    public void testGeneratedFileNewlines() {
+        try {
+                Files.createDirectories(Paths.get(GENERATED_SOURCES_DIRECTORY, "tool_test_newline_test"));
+        } catch (IOException e) {
+                Assert.fail("Could not create target directories", e);
+        }
+
+        Path protoFilePath = Paths.get(RESOURCE_DIRECTORY.toString(), PROTO_FILE_DIRECTORY, "data-types", 
+                "message.proto");
+        Path outputDirPath = Paths.get(GENERATED_SOURCES_DIRECTORY, "tool_test_newline_test");
+        Path generatedFile = outputDirPath.resolve("message_pb.bal");
+
+        generateSourceCode(protoFilePath, outputDirPath, null, null);
+        Assert.assertTrue(Files.exists(generatedFile), "Generated file does not exist");
+
+        try {
+                String content = Files.readString(generatedFile);
+                int newlineCount = 0;
+                int index = content.length() - 1;
+                
+                // check for newlines at the end of the file
+                while (index >= 0 && content.charAt(index) == '\n') {
+                newlineCount++;
+                index--;
+                }
+                
+                //if the newline count is not 1, fail the test
+                Assert.assertEquals(newlineCount, 1, 
+                "Generated file should have exactly one newline at the end, found " + newlineCount);
+        } catch (IOException e) {
+                Assert.fail("Failed to read generated file", e);
+        }
+    }
 }

--- a/tooling-tests/src/test/java/io/ballerina/protoc/tools/ToolingCommonTest.java
+++ b/tooling-tests/src/test/java/io/ballerina/protoc/tools/ToolingCommonTest.java
@@ -351,9 +351,9 @@ public class ToolingCommonTest {
     @Test
     public void testGeneratedFileNewlines() {
         try {
-                Files.createDirectories(Paths.get(GENERATED_SOURCES_DIRECTORY, "tool_test_newline_test"));
+            Files.createDirectories(Paths.get(GENERATED_SOURCES_DIRECTORY, "tool_test_newline_test"));
         } catch (IOException e) {
-                Assert.fail("Could not create target directories", e);
+            Assert.fail("Could not create target directories", e);
         }
 
         Path protoFilePath = Paths.get(RESOURCE_DIRECTORY.toString(), PROTO_FILE_DIRECTORY, "data-types", 
@@ -365,21 +365,21 @@ public class ToolingCommonTest {
         Assert.assertTrue(Files.exists(generatedFile), "Generated file does not exist");
 
         try {
-                String content = Files.readString(generatedFile);
-                int newlineCount = 0;
-                int index = content.length() - 1;
+            String content = Files.readString(generatedFile);
+            int newlineCount = 0;
+            int index = content.length() - 1;
                 
-                // check for newlines at the end of the file
-                while (index >= 0 && content.charAt(index) == '\n') {
+            // check for newlines at the end of the file
+            while (index >= 0 && content.charAt(index) == '\n') {
                 newlineCount++;
                 index--;
-                }
+            }
                 
-                //if the newline count is not 1, fail the test
-                Assert.assertEquals(newlineCount, 1, 
+            // if the newline count is not 1, fail the test
+            Assert.assertEquals(newlineCount, 1, 
                 "Generated file should have exactly one newline at the end, found " + newlineCount);
         } catch (IOException e) {
-                Assert.fail("Failed to read generated file", e);
+            Assert.fail("Failed to read generated file", e);
         }
     }
 }


### PR DESCRIPTION
- Resolved an issue where generated ballerina source files for grpc tool contained extra trailing newlines.
- Updated the writeOutputFile method to ensure only one newline at the end of each generated file.
- Added a test case to verify the newline handling.

## Purpose

Resolves [#3953](https://github.com/ballerina-platform/ballerina-library/issues/3953)

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
